### PR TITLE
fix: Remove unnecessary test text from Doc component

### DIFF
--- a/apps/doc/src/app/page.tsx
+++ b/apps/doc/src/app/page.tsx
@@ -7,7 +7,6 @@ export default function Doc() {
     <div>
       <h1>{title}</h1>
       <p>Hello {title}</p>
-      <p>test test</p>
     </div>
   );
 }


### PR DESCRIPTION
The unnecessary "test test" text was removed from the Doc component in order to 
clean up the code and improve readability.