### PR TITLE
feat: Remove unnecessary HTTP method from curl command

### DIFF
--- a/.github/workflows/production-deploy-by-tag-doc-coolify.yml
+++ b/.github/workflows/production-deploy-by-tag-doc-coolify.yml
@@ -32,6 +32,5 @@ jobs:
         #     --header "Authorization: Bearer ${{ env.COOLIFY_TOKEN }}"
         run: |
           curl ${{ env.COOLIFY_SERVER_URL }}/api/v1/deploy?uuid=${{ env.COOLIFY_PROJECT_ID }}&tag=${{ github.ref_name }} \
-            -X GET \
             -H 'content-type: application/json' \
             -H 'authorization: Bearer ${{ secrets.CRON_API_KEY }}'


### PR DESCRIPTION
Remove the -X GET flag from the curl command in the production deployment workflow file to simplify and improve readability.