### PR TITLE
ci: Update cURL request URL in production deploy workflow

### DIFF
--- a/.github/workflows/production-deploy-by-tag-doc-coolify.yml
+++ b/.github/workflows/production-deploy-by-tag-doc-coolify.yml
@@ -20,13 +20,9 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Print Tag Name
-        run: |
-         echo "Tag name from github.ref_name: ${{  github.ref_name }}"
-
       - name: cURL request
         if: ${{ env.COOLIFY_SERVER_URL && github.ref_name && env.COOLIFY_TOKEN && env.COOLIFY_PROJECT_ID }}
         run: |
           curl --request GET \
-            --url '${{ env.COOLIFY_SERVER_URL }}/api/v1/deploy?uuid=${{ env.COOLIFY_PROJECT_ID }}&tag=${{ github.ref_name }}' \
+            --url '${{ env.COOLIFY_SERVER_URL }}/api/v1/deploy?uuid=${{ env.COOLIFY_PROJECT_ID }}' \
             --header "Authorization: Bearer ${{ env.COOLIFY_TOKEN }}"


### PR DESCRIPTION
Update the cURL request URL in the production deploy workflow to remove the tag name parameter. This change ensures the correct deployment API endpoint is called without including the tag name.