### PR TITLE
build: Add turbo build step to Dockerfile for web and apps/web

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,62 +1,60 @@
 ARG NODE_VERSION=20
-
-# Alpine image
 FROM node:${NODE_VERSION}-alpine AS alpine
-RUN apk update
-RUN apk add --no-cache libc6-compat
 
-# Setup pnpm and turbo on the alpine base
-FROM alpine as base
-RUN npm install pnpm turbo --global
-RUN pnpm config set store-dir ~/.pnpm-store
+FROM alpine AS base
 
-# Prune projects
-FROM base AS pruner
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+FROM base AS builder
 ARG PROJECT=web
-
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+RUN apk update
+# Set working directory
 WORKDIR /app
+# RUN npm install -g pnpm
+RUN pnpm add turbo --global
 COPY . .
 RUN turbo prune --scope=${PROJECT} --docker
 
-# Build the project
-FROM base AS builder
-ARG PROJECT=web
-
+# Add lockfile and package.json's of isolated subworkspace
+FROM base AS installer
+RUN apk add --no-cache libc6-compat
+RUN apk update
 WORKDIR /app
-
-# Copy lockfile and package.json's of isolated subworkspace
-COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
-COPY --from=pruner /app/out/pnpm-workspace.yaml ./pnpm-workspace.yaml
-COPY --from=pruner /app/out/json/ .
 
 # First install the dependencies (as they change less often)
-RUN --mount=type=cache,id=pnpm,target=~/.pnpm-store pnpm install --frozen-lockfile
+COPY .gitignore .gitignore
+COPY --from=builder /app/out/json/ .
+COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=builder /app/out/pnpm-workspace.yaml ./pnpm-workspace.yaml
+RUN pnpm install
 
-# Copy source code of isolated subworkspace
-COPY --from=pruner /app/out/full/ .
+# Build the project
+COPY --from=builder /app/out/full/ .
+COPY turbo.json turbo.json
 
-RUN turbo build --filter=${PROJECT}
-RUN --mount=type=cache,id=pnpm,target=~/.pnpm-store pnpm prune --prod --no-optional
-RUN rm -rf ./**/*/src
+RUN pnpm turbo build --filter=${PROJECT}
 
-# Final image
-FROM alpine AS runner
+FROM base AS runner
 ARG PROJECT=web
-
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nodejs
-USER nodejs
-
 WORKDIR /app
 
-COPY --from=builder --chown=nodejs:nodejs /app/apps/${PROJECT}/next.config.js .
-COPY --from=builder --chown=nodejs:nodejs /app/apps/${PROJECT}/package.json .
+# Don't run production as root
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+USER nextjs
+
+COPY --from=installer /app/apps/${PROJECT}/next.config.js .
+COPY --from=installer /app/apps/${PROJECT}/package.json .
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nodejs:nodejs /app/apps/${PROJECT}/.next/standalone ./
-COPY --from=builder --chown=nodejs:nodejs /app/apps/${PROJECT}/.next/static ./apps/${PROJECT}/.next/static
-COPY --from=builder --chown=nodejs:nodejs /app/apps/${PROJECT}/public ./apps/${PROJECT}/public
+COPY --from=installer --chown=nextjs:nodejs /app/apps/${PROJECT}/.next/standalone ./
+COPY --from=installer --chown=nextjs:nodejs /app/apps/${PROJECT}/.next/static ./apps/${PROJECT}/.next/static
+COPY --from=installer --chown=nextjs:nodejs /app/apps/${PROJECT}/public ./apps/${PROJECT}/public
 
 WORKDIR /app/apps/${PROJECT}
 

--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -1,62 +1,60 @@
 ARG NODE_VERSION=20
-
-# Alpine image
 FROM node:${NODE_VERSION}-alpine AS alpine
-RUN apk update
-RUN apk add --no-cache libc6-compat
 
-# Setup pnpm and turbo on the alpine base
-FROM alpine as base
-RUN npm install pnpm turbo --global
-RUN pnpm config set store-dir ~/.pnpm-store
+FROM alpine AS base
 
-# Prune projects
-FROM base AS pruner
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+FROM base AS builder
 ARG PROJECT=web
-
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+RUN apk update
+# Set working directory
 WORKDIR /app
+# RUN npm install -g pnpm
+RUN pnpm add turbo --global
 COPY . .
 RUN turbo prune --scope=${PROJECT} --docker
 
-# Build the project
-FROM base AS builder
-ARG PROJECT=web
-
+# Add lockfile and package.json's of isolated subworkspace
+FROM base AS installer
+RUN apk add --no-cache libc6-compat
+RUN apk update
 WORKDIR /app
-
-# Copy lockfile and package.json's of isolated subworkspace
-COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
-COPY --from=pruner /app/out/pnpm-workspace.yaml ./pnpm-workspace.yaml
-COPY --from=pruner /app/out/json/ .
 
 # First install the dependencies (as they change less often)
-RUN --mount=type=cache,id=pnpm,target=~/.pnpm-store pnpm install --frozen-lockfile
+COPY .gitignore .gitignore
+COPY --from=builder /app/out/json/ .
+COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=builder /app/out/pnpm-workspace.yaml ./pnpm-workspace.yaml
+RUN pnpm install
 
-# Copy source code of isolated subworkspace
-COPY --from=pruner /app/out/full/ .
+# Build the project
+COPY --from=builder /app/out/full/ .
+COPY turbo.json turbo.json
 
-RUN turbo build --filter=${PROJECT}
-RUN --mount=type=cache,id=pnpm,target=~/.pnpm-store pnpm prune --prod --no-optional
-RUN rm -rf ./**/*/src
+RUN pnpm turbo build --filter=${PROJECT}
 
-# Final image
-FROM alpine AS runner
+FROM base AS runner
 ARG PROJECT=web
-
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nodejs
-USER nodejs
-
 WORKDIR /app
 
-COPY --from=builder --chown=nodejs:nodejs /app/apps/${PROJECT}/next.config.js .
-COPY --from=builder --chown=nodejs:nodejs /app/apps/${PROJECT}/package.json .
+# Don't run production as root
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+USER nextjs
+
+COPY --from=installer /app/apps/${PROJECT}/next.config.js .
+COPY --from=installer /app/apps/${PROJECT}/package.json .
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nodejs:nodejs /app/apps/${PROJECT}/.next/standalone ./
-COPY --from=builder --chown=nodejs:nodejs /app/apps/${PROJECT}/.next/static ./apps/${PROJECT}/.next/static
-COPY --from=builder --chown=nodejs:nodejs /app/apps/${PROJECT}/public ./apps/${PROJECT}/public
+COPY --from=installer --chown=nextjs:nodejs /app/apps/${PROJECT}/.next/standalone ./
+COPY --from=installer --chown=nextjs:nodejs /app/apps/${PROJECT}/.next/static ./apps/${PROJECT}/.next/static
+COPY --from=installer --chown=nextjs:nodejs /app/apps/${PROJECT}/public ./apps/${PROJECT}/public
 
 WORKDIR /app/apps/${PROJECT}
 


### PR DESCRIPTION
Add turbo build step to Dockerfile for the web project and the apps/web project.
This step optimizes the build process by leveraging turbo functionalities.
Also, set up the runner image to run production as non-root user.